### PR TITLE
refactor(styles): migrate Checkout and Catalog modules to SCSS with BEM methodology

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "gh-pages": "^6.3.0",
         "globals": "^16.4.0",
         "prettier": "^3.6.2",
+        "sass": "^1.100.0",
         "stylelint": "^17.3.0",
         "stylelint-config-standard": "^40.0.0",
         "typescript": "~5.9.3",
@@ -1284,6 +1285,330 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -2309,6 +2634,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2490,6 +2831,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3309,6 +3661,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3725,6 +4084,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.23",
@@ -4196,6 +4563,20 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4294,6 +4675,28 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
+      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gh-pages": "^6.3.0",
     "globals": "^16.4.0",
     "prettier": "^3.6.2",
+    "sass": "^1.100.0",
     "stylelint": "^17.3.0",
     "stylelint-config-standard": "^40.0.0",
     "typescript": "~5.9.3",

--- a/src/App.css
+++ b/src/App.css
@@ -35,11 +35,6 @@ button:focus {
 
 @media (max-width: 768px) {
   /* Ajustes para tablets */
-  .product-grid {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)) !important;
-    gap: 1rem !important;
-  }
-
   .category-card {
     min-width: 150px !important;
     height: 120px !important;
@@ -58,10 +53,6 @@ button:focus {
 
 @media (max-width: 480px) {
   /* Ajustes para móviles */
-  .product-grid {
-    grid-template-columns: 1fr !important;
-  }
-
   nav {
     flex-direction: column;
     gap: 1rem !important;

--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -33,35 +33,48 @@ const CartModal: React.FC<CartModalProps> = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Carrito de Compras">
       {cartItems.length === 0 ? (
-        <p style={styles.emptyMessage}>Tu carrito está vacío.</p>
+        <p className="cart-modal__empty">Tu carrito está vacío.</p>
       ) : (
-        <div style={styles.cartContent}>
-          <ul style={styles.itemList}>
+        <div className="cart-modal__body">
+          <ul className="cart-modal__list">
             {cartItems.map((item) => (
-              <li key={item.id} style={styles.item}>
-                <img src={item.image} alt={item.name} style={styles.itemImage} />
-                <div style={styles.itemDetails}>
-                  <span style={styles.itemName}>{item.name}</span>
-                  <span style={styles.itemPrice}>{formatPrice(item.price)}</span>
+              <li key={item.id} className="cart-modal__item">
+                <img
+                  src={item.image}
+                  alt={item.name}
+                  className="cart-modal__item-image"
+                />
+                <div className="cart-modal__item-details">
+                  <span className="cart-modal__item-name">{item.name}</span>
+                  <span className="cart-modal__item-price">{formatPrice(item.price)}</span>
                 </div>
-                <div style={styles.itemControls}>
+                <div className="cart-modal__item-controls">
                   <input
                     type="number"
                     min="1"
                     value={item.quantity}
                     onChange={(e) => onUpdateQuantity(item.id, parseInt(e.target.value, 10))}
-                    style={styles.quantityInput}
+                    className="cart-modal__quantity-input"
+                    aria-label={`Cantidad de ${item.name}`}
                   />
-                  <button onClick={() => onRemoveFromCart(item.id)} style={styles.removeButton}>
+                  <button
+                    onClick={() => onRemoveFromCart(item.id)}
+                    className="cart-modal__remove-btn"
+                    aria-label={`Eliminar ${item.name} del carrito`}
+                  >
                     Eliminar
                   </button>
                 </div>
               </li>
             ))}
           </ul>
-          <div style={styles.summary}>
-            <p style={styles.total}>Total: {formatPrice(total)}</p>
-            <button onClick={onCheckout} style={styles.checkoutButton} disabled={isCheckoutLoading}>
+          <div className="cart-modal__summary">
+            <p className="cart-modal__total">Total: {formatPrice(total)}</p>
+            <button
+              onClick={onCheckout}
+              className="cart-modal__checkout-btn"
+              disabled={isCheckoutLoading}
+            >
               {isCheckoutLoading ? 'Procesando...' : 'Finalizar Compra'}
             </button>
           </div>
@@ -69,55 +82,6 @@ const CartModal: React.FC<CartModalProps> = ({
       )}
     </Modal>
   );
-};
-
-const styles: { [key: string]: React.CSSProperties } = {
-  cartContent: { padding: '1rem' },
-  emptyMessage: { textAlign: 'center', padding: '2rem', color: '#666' },
-  itemList: { listStyle: 'none', padding: 0, margin: 0 },
-  item: {
-    display: 'flex',
-    alignItems: 'center',
-    marginBottom: '1rem',
-    borderBottom: '1px solid #eee',
-    paddingBottom: '1rem',
-  },
-  itemImage: {
-    width: '80px',
-    height: '80px',
-    objectFit: 'cover',
-    marginRight: '1rem',
-    borderRadius: '4px',
-  },
-  itemDetails: { flex: 1, display: 'flex', flexDirection: 'column' },
-  itemName: { fontWeight: 'bold', marginBottom: '0.25rem' },
-  itemPrice: { color: '#888' },
-  itemControls: { display: 'flex', alignItems: 'center' },
-  quantityInput: { width: '50px', textAlign: 'center', marginRight: '0.5rem' },
-  removeButton: {
-    background: 'none',
-    border: '1px solid #ccc',
-    color: '#f00',
-    cursor: 'pointer',
-    padding: '0.25rem 0.5rem',
-    borderRadius: '4px',
-  },
-  summary: {
-    marginTop: '1.5rem',
-    paddingTop: '1rem',
-    borderTop: '2px solid #333',
-    textAlign: 'right',
-  },
-  total: { fontSize: '1.2rem', fontWeight: 'bold', marginBottom: '1rem' },
-  checkoutButton: {
-    backgroundColor: '#28a745',
-    color: 'white',
-    border: 'none',
-    padding: '0.75rem 1.5rem',
-    fontSize: '1rem',
-    cursor: 'pointer',
-    borderRadius: '5px',
-  },
 };
 
 export default CartModal;

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -16,24 +16,27 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onViewDetails, onAdd
     }).format(value);
 
   return (
-    <div style={styles.productCard} role="group" aria-labelledby={`product-name-${product.id}`}>
-      <div style={styles.imageContainer}>
-        {/* CORRECCIÓN: Usar product.image */}
-        <img src={product.image} alt={product.name} loading="lazy" style={styles.productImage} />
+    <div className="product-card" role="group" aria-labelledby={`product-name-${product.id}`}>
+      <div className="product-card__image-wrapper">
+        <img
+          src={product.image}
+          alt={product.name}
+          loading="lazy"
+          className="product-card__image"
+        />
       </div>
-      <div style={styles.productInfo}>
-        <h3 id={`product-name-${product.id}`} style={styles.productName}>
+      <div className="product-card__body">
+        <h3 id={`product-name-${product.id}`} className="product-card__name">
           {product.name}
         </h3>
-        {/* CORRECCIÓN: Usar product.price */}
-        <p style={styles.productPrice} aria-label={`Precio: ${product.price}`}>
+        <p className="product-card__price" aria-label={`Precio: ${product.price}`}>
           Precio: {formatPrice(product.price)}
         </p>
-        <div style={styles.buttonGroup}>
+        <div className="product-card__actions">
           {onViewDetails && (
             <button
               onClick={() => onViewDetails(product)}
-              style={styles.actionButton}
+              className="product-card__btn product-card__btn--outline"
               aria-label={`Ver detalles de ${product.name}`}
             >
               Ver Detalles
@@ -42,7 +45,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onViewDetails, onAdd
           {onAddToCart && (
             <button
               onClick={() => onAddToCart(product)}
-              style={styles.addToCartButton}
+              className="product-card__btn product-card__btn--primary"
               aria-label={`Añadir ${product.name} al carrito`}
             >
               Añadir al Carrito
@@ -52,71 +55,6 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onViewDetails, onAdd
       </div>
     </div>
   );
-};
-
-const styles: { [key: string]: React.CSSProperties } = {
-  productCard: {
-    border: '1px solid #e0e0e0',
-    borderRadius: '8px',
-    overflow: 'hidden',
-    backgroundColor: '#fff',
-    display: 'flex',
-    flexDirection: 'column',
-    transition: 'box-shadow 0.3s ease',
-  },
-  imageContainer: {
-    width: '100%',
-    paddingTop: '100%', // Aspect Ratio 1:1
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  productImage: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-  },
-  productInfo: {
-    padding: '1rem',
-    flexGrow: 1,
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  productName: {
-    fontSize: '1.1rem',
-    fontWeight: '600',
-    margin: '0 0 0.5rem 0',
-    flexGrow: 1,
-  },
-  productPrice: {
-    fontSize: '1rem',
-    color: '#333',
-    margin: '0 0 1rem 0',
-  },
-  buttonGroup: {
-    display: 'flex',
-    gap: '0.5rem',
-    marginTop: 'auto',
-  },
-  actionButton: {
-    flex: 1,
-    padding: '0.75rem',
-    border: '1px solid #ccc',
-    borderRadius: '4px',
-    background: 'transparent',
-    cursor: 'pointer',
-  },
-  addToCartButton: {
-    flex: 1,
-    padding: '0.75rem',
-    border: 'none',
-    borderRadius: '4px',
-    backgroundColor: '#007bff',
-    color: 'white',
-    cursor: 'pointer',
-  },
 };
 
 export default ProductCard;

--- a/src/components/ProductGrid.tsx
+++ b/src/components/ProductGrid.tsx
@@ -13,7 +13,7 @@ const ProductGrid: React.FC<ProductGridExtendedProps> = ({
   onAddToCart,
 }) => {
   return (
-    <div style={styles.productGrid}>
+    <div className="product-grid">
       {products.map((product) => (
         <ProductCard
           key={product.id}
@@ -24,14 +24,6 @@ const ProductGrid: React.FC<ProductGridExtendedProps> = ({
       ))}
     </div>
   );
-};
-
-const styles: { [key: string]: React.CSSProperties } = {
-  productGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-    gap: '1.5rem',
-  },
 };
 
 export default ProductGrid;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -45,16 +45,16 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
   };
 
   return (
-    <aside style={styles.sidebar} role="complementary" aria-label="Filtros de productos">
-      <h2 style={styles.sidebarTitle}>Filtros</h2>
+    <aside className="sidebar" role="complementary" aria-label="Filtros de productos">
+      <h2 className="sidebar__title">Filtros</h2>
 
       {/* Tipo de bicicleta */}
-      <div style={styles.filterGroup}>
-        <label style={styles.filterLabel}>Tipo de bicicleta</label>
+      <div className="sidebar__group">
+        <label className="sidebar__label">Tipo de bicicleta</label>
         <select
           value={localFilters.tipo}
           onChange={(e) => handleFilterChange('tipo', e.target.value)}
-          style={styles.select}
+          className="sidebar__select"
           aria-label="Filtrar por tipo de bicicleta"
         >
           {tiposBicicleta.map((tipo) => (
@@ -66,12 +66,12 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
       </div>
 
       {/* Marca de bicicleta */}
-      <div style={styles.filterGroup}>
-        <label style={styles.filterLabel}>Marca de bicicleta</label>
+      <div className="sidebar__group">
+        <label className="sidebar__label">Marca de bicicleta</label>
         <select
           value={localFilters.marca}
           onChange={(e) => handleFilterChange('marca', e.target.value)}
-          style={styles.select}
+          className="sidebar__select"
           aria-label="Filtrar por marca"
         >
           {marcasBicicleta.map((marca) => (
@@ -83,12 +83,12 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
       </div>
 
       {/* Material de bicicleta */}
-      <div style={styles.filterGroup}>
-        <label style={styles.filterLabel}>Material de bicicleta</label>
+      <div className="sidebar__group">
+        <label className="sidebar__label">Material de bicicleta</label>
         <select
           value={localFilters.material}
           onChange={(e) => handleFilterChange('material', e.target.value)}
-          style={styles.select}
+          className="sidebar__select"
           aria-label="Filtrar por material"
         >
           {materiales.map((material) => (
@@ -100,12 +100,12 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
       </div>
 
       {/* Transmisión */}
-      <div style={styles.filterGroup}>
-        <label style={styles.filterLabel}>Transmisión</label>
+      <div className="sidebar__group">
+        <label className="sidebar__label">Transmisión</label>
         <select
           value={localFilters.transmision}
           onChange={(e) => handleFilterChange('transmision', e.target.value)}
-          style={styles.select}
+          className="sidebar__select"
           aria-label="Filtrar por transmisión"
         >
           {transmisiones.map((transmision) => (
@@ -117,30 +117,32 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
       </div>
 
       {/* Rango de precios */}
-      <div style={styles.filterGroup}>
-        <label style={styles.filterLabel}>Rango de precios</label>
-        <div style={styles.priceRange}>
+      <div className="sidebar__group">
+        <label className="sidebar__label">Rango de precios</label>
+        <div className="sidebar__price-range">
           <input
             type="number"
             placeholder="Min"
             value={localFilters.precioMin || ''}
             onChange={(e) => handleFilterChange('precioMin', Number(e.target.value) || 0)}
-            style={styles.priceInput}
+            className="sidebar__price-input"
             aria-label="Precio mínimo"
           />
-          <span style={styles.priceSeparator}>-</span>
+          <span className="sidebar__price-separator">-</span>
           <input
             type="number"
             placeholder="Max"
             value={localFilters.precioMax || ''}
-            onChange={(e) => handleFilterChange('precioMax', Number(e.target.value) || 10000000)}
-            style={styles.priceInput}
+            onChange={(e) =>
+              handleFilterChange('precioMax', Number(e.target.value) || 10000000)
+            }
+            className="sidebar__price-input"
             aria-label="Precio máximo"
           />
         </div>
         <button
           onClick={handleApplyFilters}
-          style={styles.applyButton}
+          className="sidebar__btn sidebar__btn--apply"
           aria-label="Aplicar filtros"
         >
           Aplicar
@@ -150,103 +152,13 @@ const Sidebar: React.FC<SidebarProps> = ({ filters, onFilterChange }) => {
       {/* Botón reset */}
       <button
         onClick={handleResetFilters}
-        style={styles.resetButton}
+        className="sidebar__btn sidebar__btn--reset"
         aria-label="Restablecer filtros"
       >
         Restablecer filtros
       </button>
     </aside>
   );
-};
-
-const styles: { [key: string]: React.CSSProperties } = {
-  sidebar: {
-    backgroundColor: '#f8f8f8',
-    padding: '1.5rem',
-    borderRadius: '8px',
-    minWidth: '250px',
-    maxWidth: '300px',
-    width: '100%',
-    height: 'fit-content',
-    position: 'sticky',
-    top: '100px',
-    overflow: 'hidden',
-    boxSizing: 'border-box',
-  },
-  sidebarTitle: {
-    fontSize: '1.25rem',
-    fontWeight: 700,
-    marginBottom: '1.5rem',
-    color: '#1a1a1a',
-  },
-  filterGroup: {
-    marginBottom: '1.5rem',
-  },
-  filterLabel: {
-    display: 'block',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    marginBottom: '0.5rem',
-    color: '#333',
-  },
-  select: {
-    width: '100%',
-    padding: '0.75rem',
-    border: '1px solid #e0e0e0',
-    borderRadius: '4px',
-    fontSize: '0.875rem',
-    backgroundColor: 'white',
-    cursor: 'pointer',
-    outline: 'none',
-    transition: 'border-color 0.2s',
-  },
-  priceRange: {
-    display: 'grid',
-    gridTemplateColumns: '1fr auto 1fr',
-    alignItems: 'center',
-    gap: '0.5rem',
-    marginBottom: '0.75rem',
-    width: '100%',
-  },
-  priceInput: {
-    width: '100%',
-    minWidth: 0,
-    padding: '0.5rem',
-    border: '1px solid #e0e0e0',
-    borderRadius: '4px',
-    fontSize: '0.875rem',
-    outline: 'none',
-    boxSizing: 'border-box',
-  },
-  priceSeparator: {
-    color: '#666',
-    fontWeight: 500,
-  },
-  applyButton: {
-    width: '100%',
-    backgroundColor: '#ff6600',
-    color: 'white',
-    border: 'none',
-    padding: '0.75rem',
-    borderRadius: '4px',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    cursor: 'pointer',
-    transition: 'background-color 0.2s',
-  },
-  resetButton: {
-    width: '100%',
-    backgroundColor: 'transparent',
-    color: '#666',
-    border: '1px solid #e0e0e0',
-    padding: '0.75rem',
-    borderRadius: '4px',
-    fontSize: '0.875rem',
-    fontWeight: 500,
-    cursor: 'pointer',
-    marginTop: '1rem',
-    transition: 'background-color 0.2s',
-  },
 };
 
 export default Sidebar;

--- a/src/hooks/useShopify.ts
+++ b/src/hooks/useShopify.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { getProducts } from '../services/shopify';
+import type { ShopifyProduct } from '../types';
+
+export function useShopify() {
+  const [products, setProducts] = useState<ShopifyProduct[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProducts = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const productList = await getProducts();
+      setProducts(productList);
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchProducts();
+  }, []);
+
+  return { products, loading, error, retry: fetchProducts };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
+import './styles/main.scss';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/CheckoutMvpPage.tsx
+++ b/src/pages/CheckoutMvpPage.tsx
@@ -32,104 +32,45 @@ const CheckoutMvpPage: React.FC = () => {
     }).format(value);
 
   return (
-    <main style={styles.page}>
-      <section style={styles.card}>
-        <h1 style={styles.title}>Checkout MVP</h1>
-        <p style={styles.subtitle}>Simulacion interna de pasarela para demo.</p>
+    <main className="checkout-page">
+      <section className="checkout-page__card">
+        <h1 className="checkout-page__title">Checkout MVP</h1>
+        <p className="checkout-page__subtitle">Simulacion interna de pasarela para demo.</p>
 
         {!payload ? (
-          <p style={styles.empty}>No hay informacion de checkout disponible.</p>
+          <p className="checkout-page__empty">No hay informacion de checkout disponible.</p>
         ) : (
-          <div style={styles.summary}>
-            <p style={styles.row}>
+          <div className="checkout-page__summary">
+            <p className="checkout-page__row">
               <strong>Referencia:</strong> {payload.reference}
             </p>
-            <p style={styles.row}>
+            <p className="checkout-page__row">
               <strong>Total:</strong> {formatPrice(payload.amount)}
             </p>
-            <p style={styles.row}>
+            <p className="checkout-page__row">
               <strong>Items:</strong> {payload.items}
             </p>
           </div>
         )}
 
         {paid ? (
-          <p style={styles.success}>Pago simulado exitoso.</p>
+          <p className="checkout-page__success">Pago simulado exitoso.</p>
         ) : (
-          <button type="button" style={styles.payButton} onClick={() => setPaid(true)}>
+          <button
+            type="button"
+            className="checkout-page__btn checkout-page__btn--pay"
+            onClick={() => setPaid(true)}
+          >
             Pagar (Demo)
           </button>
         )}
 
-        <Link to="/" style={styles.link}>
+        <Link to="/" className="checkout-page__link">
           Volver al inicio
         </Link>
       </section>
     </main>
   );
-};
-
-const styles: { [key: string]: React.CSSProperties } = {
-  page: {
-    minHeight: '100vh',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '1rem',
-    background: '#0f172a',
-  },
-  card: {
-    width: '100%',
-    maxWidth: '560px',
-    background: '#ffffff',
-    borderRadius: '12px',
-    padding: '1.5rem',
-    boxShadow: '0 10px 30px rgba(15, 23, 42, 0.25)',
-  },
-  title: {
-    margin: 0,
-    fontSize: '1.5rem',
-  },
-  subtitle: {
-    marginTop: '0.5rem',
-    color: '#475569',
-  },
-  summary: {
-    marginTop: '1rem',
-    padding: '1rem',
-    borderRadius: '8px',
-    background: '#f8fafc',
-    border: '1px solid #e2e8f0',
-  },
-  row: {
-    margin: '0.25rem 0',
-  },
-  empty: {
-    marginTop: '1rem',
-    color: '#64748b',
-  },
-  payButton: {
-    marginTop: '1rem',
-    width: '100%',
-    border: 'none',
-    background: '#ea580c',
-    color: '#ffffff',
-    borderRadius: '8px',
-    padding: '0.75rem',
-    fontWeight: 700,
-    cursor: 'pointer',
-  },
-  success: {
-    marginTop: '1rem',
-    color: '#166534',
-    fontWeight: 600,
-  },
-  link: {
-    marginTop: '1rem',
-    display: 'inline-block',
-    color: '#0f172a',
-    textDecoration: 'underline',
-  },
 };
 
 export default CheckoutMvpPage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 ﻿import React, { useState, useEffect } from 'react';
-import type { Product, CartItem, FilterState, ShopifyProduct } from '../types';
-import { getProducts } from '../services/shopify';
+import type { Product, CartItem, FilterState } from '../types';
+import { useShopify } from '../hooks/useShopify';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import Sidebar from '../components/Sidebar';
@@ -15,8 +15,8 @@ const CART_STORAGE_KEY = 'sena_ecommerce_cart';
 const CHECKOUT_STORAGE_KEY = 'sena_ecommerce_checkout_payload';
 
 const HomePage: React.FC = () => {
+  const { products: shopifyProducts, loading, error, retry } = useShopify();
   const [filteredProducts, setFilteredProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
   const [filters, setFilters] = useState<FilterState>({
     tipo: 'Todas',
     marca: 'Todas',
@@ -34,11 +34,8 @@ const HomePage: React.FC = () => {
   const [isCheckoutLoading, setIsCheckoutLoading] = useState(false);
 
   useEffect(() => {
-    const fetchProductsFromShopify = async () => {
-      setLoading(true);
-      const shopifyProducts: ShopifyProduct[] = await getProducts();
-
-      const formattedProducts: Product[] = shopifyProducts.map((p: ShopifyProduct) => ({
+    if (shopifyProducts.length > 0) {
+      const formattedProducts: Product[] = shopifyProducts.map((p) => ({
         id: p.id,
         name: p.title,
         description: p.description,
@@ -51,13 +48,9 @@ const HomePage: React.FC = () => {
         color: 'N/A',
         tamaño: 'N/A',
       }));
-
       setFilteredProducts(formattedProducts);
-      setLoading(false);
-    };
-
-    fetchProductsFromShopify();
-  }, []);
+    }
+  }, [shopifyProducts]);
 
   useEffect(() => {
     const storedCart = localStorage.getItem(CART_STORAGE_KEY);
@@ -141,6 +134,11 @@ const HomePage: React.FC = () => {
         <main style={{ flex: 1, padding: '2rem' }}>
           {loading ? (
             <p>Cargando productos desde Shopify...</p>
+          ) : error ? (
+            <div>
+              <p>Error al cargar los productos: {error.message}</p>
+              <button onClick={retry}>Reintentar</button>
+            </div>
           ) : (
             <ProductGrid
               products={filteredProducts}

--- a/src/styles/catalog/_product-card.scss
+++ b/src/styles/catalog/_product-card.scss
@@ -1,0 +1,110 @@
+// ============================================================
+// Block: product-card
+// Módulo: Catálogo
+// Metodología: BEM (máximo 2 niveles de anidamiento)
+// ============================================================
+
+.product-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  }
+}
+
+// Element: product-card__image-wrapper
+.product-card__image-wrapper {
+  width: 100%;
+  padding-top: 100%; // ratio 1:1
+  position: relative;
+  overflow: hidden;
+}
+
+// Element: product-card__image
+.product-card__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.35s ease;
+
+  .product-card:hover & {
+    transform: scale(1.05);
+  }
+}
+
+// Element: product-card__body
+.product-card__body {
+  padding: 1rem;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+// Element: product-card__name
+.product-card__name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  flex-grow: 1;
+  color: #1a1a1a;
+}
+
+// Element: product-card__price
+.product-card__price {
+  font-size: 1rem;
+  color: #555;
+  margin: 0 0 1rem;
+}
+
+// Element: product-card__actions
+.product-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+// Element: product-card__btn (base compartida)
+.product-card__btn {
+  flex: 1;
+  padding: 0.75rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    opacity 0.2s;
+}
+
+// Modifier: product-card__btn--outline
+.product-card__btn--outline {
+  border: 1px solid #ccc;
+  background: transparent;
+  color: #333;
+
+  &:hover {
+    background: #f5f5f5;
+  }
+}
+
+// Modifier: product-card__btn--primary
+.product-card__btn--primary {
+  border: none;
+  background-color: #0066cc;
+  color: #fff;
+
+  &:hover {
+    background-color: #0052a3;
+  }
+}

--- a/src/styles/catalog/_product-grid.scss
+++ b/src/styles/catalog/_product-grid.scss
@@ -1,0 +1,29 @@
+// ============================================================
+// Block: product-grid
+// Módulo: Catálogo
+// Metodología: BEM (máximo 2 niveles de anidamiento)
+// ============================================================
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Element: product-grid__empty
+.product-grid__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #666;
+  font-size: 1rem;
+}

--- a/src/styles/catalog/_sidebar.scss
+++ b/src/styles/catalog/_sidebar.scss
@@ -1,0 +1,141 @@
+// ============================================================
+// Block: sidebar
+// Módulo: Catálogo — Panel de filtros
+// Metodología: BEM (máximo 2 niveles de anidamiento)
+// ============================================================
+
+.sidebar {
+  background-color: #f8f8f8;
+  padding: 1.5rem;
+  border-radius: 8px;
+  min-width: 250px;
+  max-width: 300px;
+  width: 100%;
+  height: fit-content;
+  position: sticky;
+  top: 100px;
+  overflow: hidden;
+  box-sizing: border-box;
+
+  @media (max-width: 968px) {
+    max-width: 100%;
+    position: relative;
+    top: 0;
+  }
+}
+
+// Element: sidebar__title
+.sidebar__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  color: #1a1a1a;
+}
+
+// Element: sidebar__group
+.sidebar__group {
+  margin-bottom: 1.5rem;
+}
+
+// Element: sidebar__label
+.sidebar__label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+// Element: sidebar__select
+.sidebar__select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background-color: #fff;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: #ff6600;
+    box-shadow: 0 0 0 2px rgba(255, 102, 0, 0.15);
+  }
+}
+
+// Element: sidebar__price-range
+.sidebar__price-range {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  width: 100%;
+}
+
+// Element: sidebar__price-input
+.sidebar__price-input {
+  width: 100%;
+  min-width: 0;
+  padding: 0.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: #ff6600;
+    box-shadow: 0 0 0 2px rgba(255, 102, 0, 0.15);
+  }
+}
+
+// Element: sidebar__price-separator
+.sidebar__price-separator {
+  color: #666;
+  font-weight: 500;
+  text-align: center;
+}
+
+// Element: sidebar__btn (base compartida)
+.sidebar__btn {
+  width: 100%;
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    opacity 0.2s;
+}
+
+// Modifier: sidebar__btn--apply
+.sidebar__btn--apply {
+  border: none;
+  background-color: #ff6600;
+  color: #fff;
+
+  &:hover {
+    background-color: #e05500;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+// Modifier: sidebar__btn--reset
+.sidebar__btn--reset {
+  background-color: transparent;
+  color: #666;
+  border: 1px solid #e0e0e0;
+  margin-top: 1rem;
+
+  &:hover {
+    background-color: #f0f0f0;
+    border-color: #ccc;
+  }
+}

--- a/src/styles/checkout/_cart-modal.scss
+++ b/src/styles/checkout/_cart-modal.scss
@@ -1,0 +1,154 @@
+// ============================================================
+// Block: cart-modal
+// Módulo: Checkout — Carrito de compras
+// Metodología: BEM (máximo 2 niveles de anidamiento)
+// ============================================================
+
+// Element: cart-modal__body
+.cart-modal__body {
+  padding: 1rem;
+}
+
+// Element: cart-modal__empty
+.cart-modal__empty {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+  font-size: 0.95rem;
+}
+
+// Element: cart-modal__list
+.cart-modal__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+// Element: cart-modal__item
+.cart-modal__item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 1rem;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+}
+
+// Element: cart-modal__item-image
+.cart-modal__item-image {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin-right: 1rem;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+// Element: cart-modal__item-details
+.cart-modal__item-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+// Element: cart-modal__item-name
+.cart-modal__item-name {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  color: #1a1a1a;
+  font-size: 0.95rem;
+}
+
+// Element: cart-modal__item-price
+.cart-modal__item-price {
+  color: #888;
+  font-size: 0.875rem;
+}
+
+// Element: cart-modal__item-controls
+.cart-modal__item-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+// Element: cart-modal__quantity-input
+.cart-modal__quantity-input {
+  width: 54px;
+  text-align: center;
+  padding: 0.3rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: #0066cc;
+  }
+}
+
+// Element: cart-modal__remove-btn
+.cart-modal__remove-btn {
+  background: none;
+  border: 1px solid #ccc;
+  color: #dc2626;
+  cursor: pointer;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    background-color: #fee2e2;
+    border-color: #fca5a5;
+  }
+}
+
+// Element: cart-modal__summary
+.cart-modal__summary {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 2px solid #1a1a1a;
+  text-align: right;
+}
+
+// Element: cart-modal__total
+.cart-modal__total {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #1a1a1a;
+}
+
+// Element: cart-modal__checkout-btn
+.cart-modal__checkout-btn {
+  background-color: #16a34a;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 6px;
+  transition:
+    background-color 0.2s,
+    opacity 0.2s;
+
+  &:hover:not(:disabled) {
+    background-color: #15803d;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/src/styles/checkout/_checkout-page.scss
+++ b/src/styles/checkout/_checkout-page.scss
@@ -1,0 +1,124 @@
+// ============================================================
+// Block: checkout-page
+// Módulo: Checkout
+// Metodología: BEM (máximo 2 niveles de anidamiento)
+// ============================================================
+
+.checkout-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: #0f172a;
+}
+
+// Element: checkout-page__card
+.checkout-page__card {
+  width: 100%;
+  max-width: 560px;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+
+  @media (max-width: 480px) {
+    padding: 1.25rem;
+    border-radius: 8px;
+  }
+}
+
+// Element: checkout-page__title
+.checkout-page__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+// Element: checkout-page__subtitle
+.checkout-page__subtitle {
+  margin-top: 0.5rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+// Element: checkout-page__summary
+.checkout-page__summary {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+// Element: checkout-page__row
+.checkout-page__row {
+  margin: 0.25rem 0;
+  font-size: 0.95rem;
+  color: #334155;
+
+  strong {
+    color: #0f172a;
+  }
+}
+
+// Element: checkout-page__empty
+.checkout-page__empty {
+  margin-top: 1rem;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+// Element: checkout-page__success
+.checkout-page__success {
+  margin-top: 1rem;
+  color: #166534;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  background: #dcfce7;
+  border-radius: 6px;
+  border: 1px solid #bbf7d0;
+}
+
+// Element: checkout-page__link
+.checkout-page__link {
+  margin-top: 1rem;
+  display: inline-block;
+  color: #0f172a;
+  text-decoration: underline;
+  font-size: 0.9rem;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
+// Element: checkout-page__btn (base compartida)
+.checkout-page__btn {
+  margin-top: 1rem;
+  width: 100%;
+  border: none;
+  border-radius: 8px;
+  padding: 0.875rem;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    transform 0.1s;
+}
+
+// Modifier: checkout-page__btn--pay
+.checkout-page__btn--pay {
+  background: #ea580c;
+  color: #ffffff;
+
+  &:hover {
+    background: #c2410c;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,0 +1,13 @@
+// ============================================================
+// main.scss — Entrypoint de estilos globales
+// Importa todos los parciales SCSS por módulo
+// ============================================================
+
+// Módulo: Catálogo
+@use 'catalog/product-card';
+@use 'catalog/product-grid';
+@use 'catalog/sidebar';
+
+// Módulo: Checkout
+@use 'checkout/checkout-page';
+@use 'checkout/cart-modal';


### PR DESCRIPTION
What does this PR do?
Migrates the styles of the Checkout and Catalog modules from inline JavaScript objects (React.CSSProperties) to standalone SCSS files structured under the BEM methodology (Block__Element--Modifier), with a maximum of 2 nesting levels.

Motivation
Inline styles in React have critical maintainability limitations: they don't support pseudoclasses (:hover, :focus, :disabled), don't allow media queries, increase coupling between logic and presentation, and hinder design scalability by following no naming convention.

Changes
Installed sass as a devDependency (native Vite support).
New style architecture under src/styles/ with partials organized by module:
catalog/_product-card.scss, _product-grid.scss, _sidebar.scss
checkout/_checkout-page.scss, _cart-modal.scss
main.scss as the entrypoint using @use for all partials.
Migrated 5 components — complete removal of the styles object from each .tsx file and replacement with BEM className attributes.
Cleaned up App.css — removed stale .product-grid overrides with !important that became redundant once breakpoints were moved into the component's SCSS file.
Result
Reduced CSS specificity and eliminated unnecessary !important declarations.
Interactive states (:hover, :focus, :disabled) are now handled in SCSS.
Clear separation between component logic and visual styles.
Build verified: ✅ npm run build — 62 modules, 0 errors.